### PR TITLE
chore ci save agent artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,4 +256,22 @@ jobs:
       - name: Run agent dispatcher
         run: python -m scripts.agents.dispatcher --task i18n_review --payload "{}"
 
+      - name: Save agent result and check ok
+        shell: bash
+        run: |
+          set -e
+          mkdir -p artifacts/agent_reports
+          python -m scripts.agents.dispatcher --task i18n_review --payload "{}" | tee artifacts/agent_reports/i18n_review.json
+          ok=$(cat artifacts/agent_reports/i18n_review.json | jq -r '.ok')
+          if [ "$ok" != "true" ]; then
+            echo agent returned not ok
+            exit 1
+          fi
+
+      - name: Upload agent result
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-i18n-review
+          path: artifacts/agent_reports/i18n_review.json
+
 


### PR DESCRIPTION
add artifact upload and ok guard

## Changes
- Extend dispatcher step to save JSON output to artifacts/agent_reports/i18n_review.json
- Add ok field validation that fails CI if agent returns not ok
- Upload agent result as GitHub Actions artifact

## Impact
- Agent results are now preserved as artifacts
- CI fails fast if agent reports error
- No existing workflow logic changed