### PR TITLE
chore workflow add ai dispatcher

### DIFF
--- a/.github/workflows/ai-dispatcher.yml
+++ b/.github/workflows/ai-dispatcher.yml
@@ -2,6 +2,9 @@ name: ai-dispatcher
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+  schedule:
+    - cron: '15 3 * * MON'
 permissions:
   contents: write
   pull-requests: write
@@ -43,3 +46,20 @@ jobs:
         run: |
           gh pr list --state open --json number,title,mergeStateStatus,autoMergeRequest \
             --jq '.[] | [.number,(if .autoMergeRequest then "ARMED" else "NOT-ARMED" end),.mergeStateStatus,.title] | @tsv'
+
+  env-hardening:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run env hardening dispatch
+        run: |
+          mkdir -p artifacts/agent_reports
+          python -m scripts.agents.dispatcher --task env_hardening --payload "{}" | tee artifacts/agent_reports/env_hardening.json
+      - name: Upload env hardening result
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-env-hardening
+          path: artifacts/agent_reports/env_hardening.json


### PR DESCRIPTION
add operations workflow for env hardening

## Changes
- Add workflow_dispatch and schedule triggers to ai-dispatcher.yml
- Add env-hardening job that runs weekly on Monday 3:15 AM
- Executes dispatcher with env_hardening task
- Uploads result as artifact

## Impact
- No impact on existing dispatch job
- Operations workflow for env hardening validation
- Manual execution also supported