### PR TITLE
chore workflow: set cron for JST Mon 03:15

### DIFF
--- a/.github/workflows/ai-dispatcher.yml
+++ b/.github/workflows/ai-dispatcher.yml
@@ -4,7 +4,7 @@ on:
     types: [created]
   workflow_dispatch:
   schedule:
-    - cron: '15 3 * * MON'
+    - cron: '15 18 * * SUN'
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
adjust cron to 18:15 UTC (Mon 03:15 JST)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow scheduling for automated maintenance tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->