### PR TITLE
ci pytest: add coverage gate

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,6 +28,7 @@ jobs:
           coverage run -m pytest -q scripts/agents/tests --maxfail=1
           coverage xml
           coverage html
+          coverage report --fail-under=60
         env:
           PYTHONPATH: ${{ github.workspace }}
       - name: Upload coverage artifacts


### PR DESCRIPTION
add fail-under 60 to coverage report; keep job name tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing pipeline with a minimum code coverage requirement to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->