### PR TITLE
ci: add PR-only guards to PR-specific steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             ai_review.md
 
       - name: Comment to PR
-        if: ${{ always() }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -127,7 +127,7 @@ jobs:
             });
 
       - name: Slack notify
-        if: ${{ always() && env.WEBHOOK != '' }}
+        if: ${{ always() && env.WEBHOOK != '' && github.event_name == 'pull_request' }}
         run: |
           if [ -f ai_review.json ]; then
             SUMMARY=$(jq -r '.slack_summary' ai_review.json 2>/dev/null || echo "")
@@ -147,7 +147,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment AI review to PR (fallback to commit)
-        if: ${{ always() }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -224,7 +224,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment Agent Runner summary to PR
-        if: ${{ always() }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Overview
Add \github.event_name == 'pull_request'\ guards to PR-specific steps in ci.yml to prevent null PR context errors on main branch pushes.

## Problem
- 20 failed runs on main branch detected
- Steps using \github.event.pull_request\ executed on direct main pushes
- Caused \Cannot read properties of null\ errors

## Solution
Added PR event guards to:
- Slack notify step (ai-agent-review job)
- Comment to PR step (ai-agent-review job)
- Comment AI review to PR (fallback to commit) step (ai-agent-review job)
- Comment Agent Runner summary to PR step (agent-runner job)

## Impact
- Prevents execution of PR-only steps on main pushes
- Maintains full PR functionality
- Fixes systematic main branch failures

## Validation
- Required checks: build-test, ai-agent-review, agent-runner, tests
- Verify main runs green after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to optimize event handling for pull requests, restricting specific notification and comment steps to run only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->