### PR TITLE
ci: add workflow-lint & make python-tests always run

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,16 +1,13 @@
 name: python-tests
 on:
   pull_request:
-    paths:
-      - "scripts/agents/**"
-      - ".github/workflows/python-tests.yml"
   push:
-    paths:
-      - "scripts/agents/**"
-      - ".github/workflows/python-tests.yml"
+    branches: [main]
+
 concurrency:
   group: python-tests-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,22 @@
+name: workflow-lint
+on:
+  pull_request:
+    paths: [".github/workflows/*.yml"]
+  push:
+    branches: [main]
+    paths: [".github/workflows/*.yml"]
+
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+          level: warning


### PR DESCRIPTION
## Overview
Add workflow linting with actionlint and fix python-tests to always run, resolving branch protection issues.

## Changes

### 1. Add workflow-lint.yml
- Uses reviewdog/action-actionlint to detect workflow issues
- Catches PR context misuse in push/schedule contexts
- Runs on workflow file changes only
- Uses workflow-lint-specific concurrency group

### 2. Fix python-tests.yml trigger
- **Before**: Only ran when scripts/agents/** changed
- **After**: Runs on all PRs and main pushes
- **Reason**: Required check 'tests' must always appear for merge to succeed
- Side benefit: CI workflow changes are now validated by python tests

## Problem Solved
PR #74 cannot merge because 'tests' required check doesn't appear when only .github/workflows/ci.yml changes. This is due to paths filter in python-tests.yml.

## Benefits
-  Prevents future PR context null reference errors (actionlint detection)
-  Resolves branch protection compatibility (tests always runs)
-  Fast feedback for all CI-related changes
-  Automated workflow validation on every workflow file change

## Validation
- Required checks will include: build-test, ai-agent-review, agent-runner, tests, workflow-lint / actionlint
- After merge, PR #74 should be unblocked and auto-merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python test workflow to trigger selectively on main branch pushes rather than all pull requests and pushes.
  * Added automated linting of workflow YAML files using actionlint via reviewdog for GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->