### PR TITLE
ci(ai-dispatcher): non-strict workflow_dispatch; keep schedule strict

### DIFF
--- a/.github/workflows/ai-dispatcher.yml
+++ b/.github/workflows/ai-dispatcher.yml
@@ -3,6 +3,11 @@ on:
   issue_comment:
     types: [created]
   workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Fail when required secrets are missing'
+        type: boolean
+        default: false
   schedule:
     - cron: '15 18 * * SUN'
 permissions:
@@ -55,6 +60,13 @@ jobs:
   env-hardening:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    env:
+      # secrets presence flags (true/false as strings)
+      HAS_OPENAI: ${{ secrets.OPENAI_API_KEY != '' }}
+      HAS_SUPABASE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY != '' }}
+      HAS_SUPABASE_URL: ${{ secrets.SUPABASE_URL != '' }}
+      # strict only for workflow_dispatch (manual); schedule is always treated as strict via job if-condition below
+      STRICT: ${{ github.event_name == 'workflow_dispatch' && inputs.strict == true }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -64,7 +76,17 @@ jobs:
         run: |
           mkdir -p artifacts/agent_reports
           python -m scripts.agents.dispatcher --task env_hardening --payload "{}" | tee artifacts/agent_reports/env_hardening.json
+      # In non-strict manual runs, only warn (do not fail) when required secrets are missing
+      - name: Warn when secrets are missing (non-strict mode)
+        if: ${{ env.STRICT != 'true' && github.event_name == 'workflow_dispatch' && (env.HAS_OPENAI != 'true' || env.HAS_SUPABASE_KEY != 'true' || env.HAS_SUPABASE_URL != 'true') }}
+        run: |
+          missing=()
+          [ "${HAS_OPENAI}" = "true" ] || missing+=("OPENAI_API_KEY")
+          [ "${HAS_SUPABASE_KEY}" = "true" ] || missing+=("SUPABASE_SERVICE_ROLE_KEY")
+          [ "${HAS_SUPABASE_URL}" = "true" ] || missing+=("SUPABASE_URL")
+          echo "::warning::Missing required secrets (non-strict run): ${missing[*]}"
       - name: Guard ok field without jq
+        if: ${{ env.STRICT == 'true' || github.event_name == 'schedule' }}
         run: |
           python - << 'PY'
           import json,sys


### PR DESCRIPTION
## Overview
Make `workflow_dispatch` runs of ai-dispatcher non-strict by default (warn-only), while keeping scheduled runs strict and failing when required secrets are missing.

## Changes
- Add `workflow_dispatch` input `strict` (boolean, default false)
- Add env flags for secrets presence (`HAS_OPENAI`, `HAS_SUPABASE_KEY`, `HAS_SUPABASE_URL`) and `STRICT`
- Add warn-only step for manual non-strict runs when secrets are missing
- Gate the Python ok-guard step to run only when `STRICT==true` or on `schedule`

## Behavior
- Manual run (workflow_dispatch):
  - Default non-strict: missing secrets produce warnings; job succeeds
  - With `strict: true`: behaves like scheduled audit (fails if secrets missing)
- Scheduled run: strict by design; fails if required secrets are missing

## Rationale
Reduces noise during manual tests while keeping nightly audit strict to catch misconfigurations. Aligns with WORKFLOW_BEST_PRACTICES.md guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow validation with an optional strict mode for manual runs to ensure all required secrets are properly configured. In non-strict mode (default), the workflow will warn if secrets are missing instead of failing, allowing for more flexible execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->