### PR TITLE
chore: align @hookform/resolvers to v3 (avoid zod v4 coupling)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@edge-runtime/vm": "latest",
     "@emotion/is-prop-valid": "latest",
-    "@hookform/resolvers": "latest",
+    "@hookform/resolvers": "^3",
     "@playwright/test": "latest",
     "@radix-ui/react-accordion": "latest",
     "@radix-ui/react-alert-dialog": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: latest
         version: 1.4.0
       '@hookform/resolvers':
-        specifier: latest
-        version: 5.2.2(react-hook-form@7.65.0(react@19.0.0))
+        specifier: ^3
+        version: 3.10.0(react-hook-form@7.65.0(react@19.0.0))
       '@playwright/test':
         specifier: latest
         version: 1.56.1
@@ -658,10 +658,10 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@hookform/resolvers@5.2.2':
-    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
-      react-hook-form: ^7.55.0
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -5281,9 +5281,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.65.0(react@19.0.0))':
+  '@hookform/resolvers@3.10.0(react-hook-form@7.65.0(react@19.0.0))':
     dependencies:
-      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.65.0(react@19.0.0)
 
   '@humanwhocodes/config-array@0.13.0':


### PR DESCRIPTION
RHF+Zod 連携箇所（components/JournalForm.tsx）が zod@3.x 前提のため、@hookform/resolvers を v3 系に明示的に固定し、zod v4 への誤依存を回避しました。\n\n- @hookform/resolvers: 5.x  3.x に変更\n- next build / lint: ローカルでグリーン\n\n将来的に Zod v4 へ全面移行する場合は、resolvers を 5.x に引き上げの上、該当箇所の修正を行ってください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraint to improve stability and ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->