### PR TITLE
feat(seizure): v1.1 - 履歴完全CRUD実装

### DIFF
--- a/app/daily-log/seizure/history/PdfExportButton.tsx
+++ b/app/daily-log/seizure/history/PdfExportButton.tsx
@@ -1,0 +1,49 @@
+"use client"
+import { Button } from "@/components/ui/button"
+import { PDFDownloadLink, Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer"
+import type { SeizureLog } from "@/lib/persistence/seizure"
+
+const styles = StyleSheet.create({
+  page: { padding: 24 },
+  title: { fontSize: 18, marginBottom: 12 },
+  row: { flexDirection: "row", borderBottom: 1, borderColor: "#ccc", paddingVertical: 4 },
+  cell: { fontSize: 10, paddingRight: 8, flexGrow: 1 },
+})
+
+function LogsPdf({ logs }: { logs: SeizureLog[] }) {
+  const formatDuration = (seconds?: number | null) => {
+    if (!seconds) return "-"
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    if (m > 0) return `${m}分${s}秒`
+    return `${s}秒`
+  }
+
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <Text style={styles.title}>発作記録 一覧（先頭 {Math.min(20, logs.length)} 件）</Text>
+        <View>
+          {logs.slice(0, 20).map((l) => (
+            <View key={l.id} style={styles.row}>
+              <Text style={[styles.cell, { flexBasis: 120 }]}> {new Date(l.occurredAt).toLocaleString("ja-JP")} </Text>
+              <Text style={styles.cell}>{l.seizureType}</Text>
+              <Text style={styles.cell}>{formatDuration(l.duration)}</Text>
+              <Text style={styles.cell}>{l.trigger || "-"}</Text>
+              <Text style={styles.cell}>{l.intervention || "-"}</Text>
+              <Text style={[styles.cell, { flexBasis: 160 }]}>{l.note || ""}</Text>
+            </View>
+          ))}
+        </View>
+      </Page>
+    </Document>
+  )
+}
+
+export default function PdfExportButton({ logs }: { logs: SeizureLog[] }) {
+  return (
+    <PDFDownloadLink document={<LogsPdf logs={logs} />} fileName={`seizure_logs_${Date.now()}.pdf`}>
+      {({ loading }: any) => <Button variant="outline">{loading ? "PDF生成中…" : "PDF"}</Button>}
+    </PDFDownloadLink>
+  )
+}

--- a/app/daily-log/seizure/history/page.tsx
+++ b/app/daily-log/seizure/history/page.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { listSeizureLogs, getSeizureLog, updateSeizureLog, deleteSeizureLog, type SeizureLog } from "@/lib/persistence/seizure"
+import { toast } from "sonner"
+import dynamic from "next/dynamic"
+
+const PdfExportButton = dynamic(() => import("./PdfExportButton"), { ssr: false }) as any
+
+export default function SeizureHistoryPage() {
+  const [logs, setLogs] = useState<SeizureLog[]>([])
+  const [loading, setLoading] = useState(false)
+  const [keyword, setKeyword] = useState("")
+  const [seizureType, setSeizureType] = useState("")
+  const [userId, setUserId] = useState("")
+  const [serviceId, setServiceId] = useState("")
+  const [start, setStart] = useState<string>("")
+  const [end, setEnd] = useState<string>("")
+
+  const csvHref = useMemo(() => {
+    const header = ["occurredAt","seizureType","duration","trigger","intervention","note","serviceId","userId"].join(",")
+    const rows = logs.map(l => [
+      l.occurredAt,
+      l.seizureType,
+      l.duration ?? "",
+      l.trigger ?? "",
+      l.intervention ?? "",
+      (l.note ?? "").replace(/\r?\n/g, " "),
+      l.serviceId ?? "",
+      l.userId ?? ""
+    ].map(v => `"${String(v).replace(/"/g,'""')}"`).join(","))
+    const csv = [header, ...rows].join("\n")
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    return URL.createObjectURL(blob)
+  }, [logs])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const list = await listSeizureLogs({
+        start: start || undefined,
+        end: end || undefined,
+        seizureType: seizureType || undefined,
+        userId: userId || undefined,
+        serviceId: serviceId || undefined,
+        keyword: keyword || undefined,
+        limit: 200
+      })
+      setLogs(list)
+    } catch (e: any) {
+      toast.error(`一覧取得に失敗しました: ${e.message || e}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [start, end, seizureType, userId, serviceId, keyword])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const handleDelete = async (id?: string) => {
+    if (!id) return
+    if (!confirm("削除してよろしいですか？")) return
+    try {
+      await deleteSeizureLog(id)
+      toast.success("削除しました")
+      refresh()
+    } catch (e: any) {
+      toast.error(`削除に失敗しました: ${e.message || e}`)
+    }
+  }
+
+  const handleInlineEdit = async (id?: string) => {
+    if (!id) return
+    try {
+      const curr = await getSeizureLog(id)
+      if (!curr) return
+      const nextNote = prompt("メモを編集", curr.note ?? "")
+      if (nextNote === null) return
+      await updateSeizureLog(id, { note: nextNote })
+      toast.success("更新しました")
+      refresh()
+    } catch (e: any) {
+      toast.error(`更新に失敗しました: ${e.message || e}`)
+    }
+  }
+
+  const formatDuration = (seconds?: number | null) => {
+    if (!seconds) return "-"
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    if (m > 0) return `${m}分${s}秒`
+    return `${s}秒`
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl p-4 md:p-6">
+      <Card className="shadow-sm">
+        <CardHeader className="pb-2 flex flex-row items-center justify-between">
+          <CardTitle className="text-xl">発作記録 履歴</CardTitle>
+          <div className="flex gap-2">
+            <a href={csvHref} download={`seizure_logs_${Date.now()}.csv`}>
+              <Button variant="outline">CSV</Button>
+            </a>
+            <PdfExportButton logs={logs} />
+            <Link href="/daily-log/seizure"><Button>新規作成</Button></Link>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
+            <div>
+              <Label>期間（From）</Label>
+              <Input type="datetime-local" value={start} onChange={(e) => setStart(e.target.value)} />
+            </div>
+            <div>
+              <Label>期間（To）</Label>
+              <Input type="datetime-local" value={end} onChange={(e) => setEnd(e.target.value)} />
+            </div>
+            <div>
+              <Label>発作タイプ</Label>
+              <Input placeholder="例: 欠神発作" value={seizureType} onChange={(e) => setSeizureType(e.target.value)} />
+            </div>
+            <div>
+              <Label>利用者</Label>
+              <Input placeholder="userId" value={userId} onChange={(e) => setUserId(e.target.value)} />
+            </div>
+            <div>
+              <Label>サービス</Label>
+              <Input placeholder="serviceId" value={serviceId} onChange={(e) => setServiceId(e.target.value)} />
+            </div>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <Label>キーワード</Label>
+                <Input placeholder="フリーワード" value={keyword} onChange={(e) => setKeyword(e.target.value)} />
+              </div>
+              <Button onClick={refresh} disabled={loading}>{loading ? "検索中…" : "検索"}</Button>
+            </div>
+          </div>
+
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[170px]">日時</TableHead>
+                  <TableHead>発作タイプ</TableHead>
+                  <TableHead>持続時間</TableHead>
+                  <TableHead>誘因</TableHead>
+                  <TableHead>対応</TableHead>
+                  <TableHead>メモ</TableHead>
+                  <TableHead className="w-[160px] text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {logs.map((l) => (
+                  <TableRow key={l.id}>
+                    <TableCell>{new Date(l.occurredAt).toLocaleString("ja-JP")}</TableCell>
+                    <TableCell>{l.seizureType}</TableCell>
+                    <TableCell>{formatDuration(l.duration)}</TableCell>
+                    <TableCell>{l.trigger || "-"}</TableCell>
+                    <TableCell>{l.intervention || "-"}</TableCell>
+                    <TableCell className="max-w-[260px] truncate" title={l.note || ""}>{l.note || ""}</TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Button variant="outline" size="sm" onClick={() => handleInlineEdit(l.id)}>編集</Button>
+                      <Button variant="destructive" size="sm" onClick={() => handleDelete(l.id)}>削除</Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {logs.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-muted-foreground py-8">データがありません</TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/daily-log/seizure/page.tsx
+++ b/app/daily-log/seizure/page.tsx
@@ -68,7 +68,10 @@ function SeizureForm() {
       <Card className="shadow-sm">
         <CardHeader className="pb-2 flex items-center justify-between">
           <CardTitle className="text-xl">発作記録</CardTitle>
-          <Button asChild variant="outline" size="sm"><a href="/daily-log">一覧に戻る</a></Button>
+          <div className="flex gap-2">
+            <Button asChild variant="outline" size="sm"><a href="/daily-log/seizure/history">履歴</a></Button>
+            <Button asChild variant="outline" size="sm"><a href="/daily-log">一覧に戻る</a></Button>
+          </div>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/lib/persistence/seizure.ts
+++ b/lib/persistence/seizure.ts
@@ -61,8 +61,177 @@ export async function saveSeizureLog(log: Omit<SeizureLog, "id" | "createdAt">):
   return saved
 }
 
-export type SeizureListParams = { start?: string; end?: string; serviceId?: string | null; userId?: string | null }
-export async function listSeizureLogs(_params: SeizureListParams = {}) {
-  // v1 skeleton: leave unimplemented beyond type; future v1.2 can extend
-  return [] as SeizureLog[]
+export type SeizureListParams = {
+  start?: string // ISO date/time lower bound (occurredAt >=)
+  end?: string // ISO date/time upper bound (occurredAt <=)
+  seizureType?: string // exact match for seizure type
+  serviceId?: string | null
+  userId?: string | null
+  keyword?: string // ilike match against text fields
+  limit?: number
+  offset?: number
+}
+
+/**
+ * List seizure logs with optional filters (Supabase first, otherwise localStorage)
+ */
+export async function listSeizureLogs(params: SeizureListParams = {}): Promise<SeizureLog[]> {
+  const supabase = getSupabase()
+  const {
+    start,
+    end,
+    seizureType,
+    serviceId,
+    userId,
+    keyword,
+    limit = 100,
+    offset = 0,
+  } = params
+
+  if (supabase) {
+    let query = supabase
+      .from("seizure_logs")
+      .select("id, service_id, user_id, occurred_at, seizure_type, duration, trigger, intervention, note, created_at")
+      .order("occurred_at", { ascending: false })
+      .range(offset, offset + limit - 1)
+
+    if (start) query = query.gte("occurred_at", start)
+    if (end) query = query.lte("occurred_at", end)
+    if (seizureType) query = query.eq("seizure_type", seizureType)
+    if (serviceId) query = query.eq("service_id", serviceId)
+    if (userId) query = query.eq("user_id", userId)
+    if (keyword && keyword.trim()) {
+      const k = `%${keyword.trim()}%`
+      query = query.or(
+        `seizure_type.ilike.${k},trigger.ilike.${k},intervention.ilike.${k},note.ilike.${k}`,
+      )
+    }
+
+    const { data, error } = await query
+    if (error) throw new Error(`Supabase list failed: ${error.message}`)
+
+    return (data || []).map((d: any) => ({
+      id: d.id,
+      serviceId: d.service_id,
+      userId: d.user_id,
+      occurredAt: d.occurred_at,
+      seizureType: d.seizure_type,
+      duration: d.duration,
+      trigger: d.trigger,
+      intervention: d.intervention,
+      note: d.note,
+      createdAt: d.created_at,
+    }))
+  }
+
+  // localStorage path
+  const existing = typeof localStorage !== "undefined" ? localStorage.getItem("seizureLogs") : null
+  const logs: SeizureLog[] = existing ? JSON.parse(existing) : []
+  let filtered = logs
+
+  if (start) filtered = filtered.filter((l) => l.occurredAt >= start)
+  if (end) filtered = filtered.filter((l) => l.occurredAt <= end)
+  if (seizureType) filtered = filtered.filter((l) => l.seizureType === seizureType)
+  if (serviceId) filtered = filtered.filter((l) => l.serviceId === serviceId)
+  if (userId) filtered = filtered.filter((l) => l.userId === userId)
+  if (keyword && keyword.trim()) {
+    const k = keyword.trim().toLowerCase()
+    filtered = filtered.filter((l) =>
+      [l.seizureType, l.trigger, l.intervention, l.note]
+        .filter(Boolean)
+        .some((v) => String(v).toLowerCase().includes(k)),
+    )
+  }
+
+  // sort desc by occurredAt
+  filtered.sort((a, b) => (a.occurredAt < b.occurredAt ? 1 : a.occurredAt > b.occurredAt ? -1 : 0))
+  return filtered.slice(offset, offset + limit)
+}
+
+export async function getSeizureLog(id: string): Promise<SeizureLog | null> {
+  const supabase = getSupabase()
+  if (supabase) {
+    const { data, error } = await supabase
+      .from("seizure_logs")
+      .select("id, service_id, user_id, occurred_at, seizure_type, duration, trigger, intervention, note, created_at")
+      .eq("id", id)
+      .single()
+    if (error) throw new Error(`Supabase get failed: ${error.message}`)
+    if (!data) return null
+    return {
+      id: data.id,
+      serviceId: data.service_id,
+      userId: data.user_id,
+      occurredAt: data.occurred_at,
+      seizureType: data.seizure_type,
+      duration: data.duration,
+      trigger: data.trigger,
+      intervention: data.intervention,
+      note: data.note,
+      createdAt: data.created_at,
+    }
+  }
+
+  const existing = localStorage.getItem("seizureLogs")
+  const logs: SeizureLog[] = existing ? JSON.parse(existing) : []
+  return logs.find((l) => l.id === id) || null
+}
+
+export async function updateSeizureLog(
+  id: string,
+  patch: Partial<Omit<SeizureLog, "id" | "createdAt">>,
+): Promise<SeizureLog> {
+  const supabase = getSupabase()
+  if (supabase) {
+    const { data, error } = await supabase
+      .from("seizure_logs")
+      .update({
+        service_id: patch.serviceId ?? undefined,
+        user_id: patch.userId ?? undefined,
+        occurred_at: patch.occurredAt ?? undefined,
+        seizure_type: patch.seizureType ?? undefined,
+        duration: patch.duration ?? undefined,
+        trigger: patch.trigger ?? undefined,
+        intervention: patch.intervention ?? undefined,
+        note: patch.note ?? undefined,
+      })
+      .eq("id", id)
+      .select()
+      .single()
+    if (error) throw new Error(`Supabase update failed: ${error.message}`)
+    return {
+      id: data.id,
+      serviceId: data.service_id,
+      userId: data.user_id,
+      occurredAt: data.occurred_at,
+      seizureType: data.seizure_type,
+      duration: data.duration,
+      trigger: data.trigger,
+      intervention: data.intervention,
+      note: data.note,
+      createdAt: data.created_at,
+    }
+  }
+
+  const existing = localStorage.getItem("seizureLogs")
+  const logs: SeizureLog[] = existing ? JSON.parse(existing) : []
+  const idx = logs.findIndex((l) => l.id === id)
+  if (idx === -1) throw new Error("Log not found")
+  const updated: SeizureLog = { ...logs[idx], ...patch }
+  logs[idx] = updated
+  localStorage.setItem("seizureLogs", JSON.stringify(logs))
+  return updated
+}
+
+export async function deleteSeizureLog(id: string): Promise<void> {
+  const supabase = getSupabase()
+  if (supabase) {
+    const { error } = await supabase.from("seizure_logs").delete().eq("id", id)
+    if (error) throw new Error(`Supabase delete failed: ${error.message}`)
+    return
+  }
+  const existing = localStorage.getItem("seizureLogs")
+  const logs: SeizureLog[] = existing ? JSON.parse(existing) : []
+  const next = logs.filter((l) => l.id !== id)
+  localStorage.setItem("seizureLogs", JSON.stringify(next))
 }


### PR DESCRIPTION
## 概要
Seizure v1.1として履歴ページと完全なCRUD機能を実装しました。Expression v1.2のパターンを踏襲しています。

## 主な変更
### lib/persistence/seizure.ts
-  **listSeizureLogs**: フィルタ付き一覧取得（日時範囲、発作タイプ、ユーザー、サービス、キーワード検索）
-  **getSeizureLog**: ID指定で単一レコード取得
-  **updateSeizureLog**: 部分更新（Partial patch）
-  **deleteSeizureLog**: 削除
- Supabase + localStorage両対応（Expression v1.2と同じパターン）

### app/daily-log/seizure/history/page.tsx
-  履歴ページ実装（フィルタUI完備）
-  期間、発作タイプ、ユーザー、サービス、キーワードでの検索
-  CSV/PDFエクスポート機能
-  インライン編集削除機能

### app/daily-log/seizure/history/PdfExportButton.tsx
-  発作記録用PDF出力コンポーネント
-  持続時間の適切なフォーマット表示

### app/daily-log/seizure/page.tsx
-  ヘッダーに履歴ページへのリンク追加

## テスト結果
-  pnpm build: 成功（新ルート確認: /daily-log/seizure/history - 172 kB）
-  pnpm exec vitest run: 15 passed
-  pnpm lint: No errors

## 次のステップ
このPRがマージされたら、以下のタスクを実施予定:
- CSV/PDF出力ロジックの共通化（lib/exporter/csv.ts抽出）
- CI workflows追加（vitest + playwright）
- playwright.config.tsのポート設定修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seizure history dashboard displaying logs with filtering and search capabilities.
  * Added PDF export functionality for seizure logs (up to 20 records per export).
  * Added CSV export option for current seizure logs.
  * Added inline editing of seizure log notes with confirmation feedback.
  * Added seizure log deletion with user confirmation.
  * Added navigation link to history page from the seizure form header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->