### PR TITLE
ci(e2e): disable legacy e2e job in ci.yml (moved to e2e.yml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
         run: pnpm test
 
   e2e-test:
+    if: ${{ false }}  # moved to .github/workflows/e2e.yml
     needs: build-test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR disables the legacy e2e-test job in .github/workflows/ci.yml to avoid duplicate E2E runs. The new e2e workflow now lives in .github/workflows/e2e.yml and is label-gated by 'e2e-required'.

What changed
- ci.yml: add job-level if: ${{ false }} to e2e-test (comment points to e2e.yml)

Why
- Prevents duplicate and slow E2E executions from the monolithic CI workflow
- Keeps required checks unchanged (build-test, tests, ai-agent-review, agent-runner)

How to verify
1) Open this PR without 'e2e-required' label: the new e2e-test (from e2e.yml) short-circuits to success; the legacy e2e-test in ci.yml is disabled (won't run).
2) Add label 'e2e-required': the e2e-test from e2e.yml runs fully (checkout, install, build, playwright).
3) Ensure required checks still run and pass: build-test, tests, ai-agent-review, agent-runner.

Notes
- Nightly e2e still runs via e2e.yml schedule at 03:00 JST.
- Follow-up candidates: store Playwright artifacts (screenshots/video) for failed runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI/CD configuration by moving end-to-end test workflows to a separate dedicated file, streamlining workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->