### PR TITLE
ci(e2e): use next start on CI and chromium-only to avoid timeouts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Test (E2E)
-        run: pnpm exec playwright test --reporter=github,html --timeout=45000 --workers=2
+        run: pnpm exec playwright test --project=chromium --reporter=github,html --timeout=45000 --workers=1
 
       - name: Upload Playwright report
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: process.env.CI ? "pnpm dev:ci" : "pnpm dev",
+    // CI ではビルド済みアプリを next start で起動して高速安定化
+    command: process.env.CI ? "pnpm start" : "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
- Playwright webServer on CI: pnpm start (production build)\n- e2e workflow: run chromium-only with 1 worker\nThis shortens runtime and avoids 20m timeouts while still proving diary flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined E2E testing configuration for improved test execution reliability.
  * Optimized CI build startup process using prebuilt application deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->