### PR TITLE
feat: add pochi daily achievements and users views

### DIFF
--- a/app/(pochi)/layout.tsx
+++ b/app/(pochi)/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react"
+
+export default function PochiLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/app/(pochi)/manage/achievements/daily/csv.ts
+++ b/app/(pochi)/manage/achievements/daily/csv.ts
@@ -1,0 +1,56 @@
+import type { DailyHeaderForm, DailyRowForm } from "./schema"
+
+const BOM = "\ufeff"
+const CRLF = "\r\n"
+
+const escapeCell = (value: string | number) => {
+  const text = String(value)
+  if (text.includes(",") || text.includes("\"") || text.includes("\n") || text.includes("\r")) {
+    return `"${text.replace(/"/g, '""')}"`
+  }
+  return text
+}
+
+export const toCsv = (
+  header: DailyHeaderForm,
+  rows: DailyRowForm[],
+  options: { includeAlerts: boolean },
+) => {
+  const filtered = options.includeAlerts ? rows : rows.filter((row) => !row.hasAlert)
+  const csvRows: string[] = []
+  csvRows.push(
+    [
+      "サービス",
+      "日付",
+      "看護師看護時間(分)",
+      "利用者名",
+      "予定ケア",
+      "実績内容",
+      "達成",
+      "アラート",
+      "メモ",
+    ]
+      .map(escapeCell)
+      .join(","),
+  )
+
+  for (const row of filtered) {
+    csvRows.push(
+      [
+        header.service,
+        header.date,
+        header.nurseMinutes,
+        row.userName,
+        row.plannedCare,
+        row.achievedDescription,
+        row.achieved ? 1 : 0,
+        row.hasAlert ? 1 : 0,
+        row.notes ?? "",
+      ]
+        .map(escapeCell)
+        .join(","),
+    )
+  }
+
+  return `${BOM}${csvRows.join(CRLF)}${CRLF}`
+}

--- a/app/(pochi)/manage/achievements/daily/page.tsx
+++ b/app/(pochi)/manage/achievements/daily/page.tsx
@@ -1,0 +1,433 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { SafeParseSuccess } from "zod"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+import { headerSchema, rowSchema, draftSchema, type DailyHeaderForm, type DailyRowForm } from "./schema"
+import { toCsv } from "./csv"
+import { UserNameInput } from "./user-name-input"
+import { cn } from "@/lib/utils"
+
+const DEFAULT_HEADER: DailyHeaderForm = {
+  service: "",
+  date: "",
+  nurseMinutes: "",
+}
+
+const AVAILABLE_SERVICES = [
+  { label: "児童発達支援", value: "child-development" },
+  { label: "放課後等デイサービス", value: "after-school" },
+  { label: "日中一時支援", value: "daytime-support" },
+]
+
+const USER_SUGGESTIONS = ["田中太郎", "山田花子", "佐藤健", "伊藤蓮"]
+
+const generateId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+const createEmptyRow = (): DailyRowForm => ({
+  id: generateId(),
+  userName: "",
+  plannedCare: "",
+  achievedDescription: "",
+  achieved: false,
+  hasAlert: false,
+  notes: "",
+})
+
+const getStorageKey = (header: DailyHeaderForm) =>
+  header.service && header.date ? `draft:achievements:${header.date}:${header.service}` : undefined
+
+const STORAGE_SCHEMA = draftSchema
+
+export default function DailyAchievementsPage() {
+  const [header, setHeader] = useState<DailyHeaderForm>(DEFAULT_HEADER)
+  const [rows, setRows] = useState<DailyRowForm[]>([createEmptyRow()])
+  const [includeAlerts, setIncludeAlerts] = useState(false)
+  const storageKey = useMemo(() => getStorageKey(header), [header.date, header.service])
+  const [loadedStorageKey, setLoadedStorageKey] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    if (!storageKey) {
+      setLoadedStorageKey(undefined)
+      return
+    }
+    if (loadedStorageKey === storageKey) {
+      return
+    }
+    const storedValue = window.localStorage.getItem(storageKey)
+    if (storedValue) {
+      try {
+        const parsed = JSON.parse(storedValue)
+        const result = STORAGE_SCHEMA.safeParse(parsed)
+        if (result.success) {
+          setHeader(result.data.header)
+          setRows(result.data.rows.map((row) => ({ ...row, id: row.id || generateId() })))
+        }
+      } catch (error) {
+        console.error("Failed to parse draft achievements", error)
+      }
+    }
+    setLoadedStorageKey(storageKey)
+  }, [storageKey, loadedStorageKey])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !storageKey || loadedStorageKey !== storageKey) {
+      return
+    }
+    if (!header.service || !header.date) {
+      return
+    }
+    const draft = { header, rows }
+    window.localStorage.setItem(storageKey, JSON.stringify(draft))
+  }, [header, rows, storageKey, loadedStorageKey])
+
+  const headerValidation = useMemo(() => headerSchema.safeParse(header), [header])
+  const headerErrors: Partial<Record<keyof DailyHeaderForm, string[]>> = headerValidation.success
+    ? {}
+    : headerValidation.error.formErrors.fieldErrors
+  const rowValidations = useMemo(() => rows.map((row) => rowSchema.safeParse(row)), [rows])
+
+  const summary = useMemo(() => {
+    const totalUsers = rows.length
+    const achievedCount = rows.filter((row) => row.achieved).length
+    const alertCount = rows.filter((row) => row.hasAlert).length
+    const nurseMinutes = Number.parseInt(header.nurseMinutes, 10)
+    return {
+      totalUsers,
+      achievedCount,
+      pendingCount: Math.max(totalUsers - achievedCount, 0),
+      alertCount,
+      nurseMinutes: Number.isNaN(nurseMinutes) ? 0 : nurseMinutes,
+    }
+  }, [rows, header.nurseMinutes])
+
+  const handleHeaderChange = useCallback(
+    (field: keyof DailyHeaderForm, value: DailyHeaderForm[keyof DailyHeaderForm]) => {
+      setHeader((current) => ({ ...current, [field]: value }))
+    },
+    [],
+  )
+
+  const handleRowChange = useCallback(
+    (rowId: string, field: keyof DailyRowForm, value: DailyRowForm[keyof DailyRowForm]) => {
+      setRows((current) => current.map((row) => (row.id === rowId ? { ...row, [field]: value } : row)))
+    },
+    [],
+  )
+
+  const addRow = useCallback(() => {
+    setRows((current) => [...current, createEmptyRow()])
+  }, [])
+
+  const removeRow = useCallback((rowId: string) => {
+    setRows((current) => (current.length > 1 ? current.filter((row) => row.id !== rowId) : current))
+  }, [])
+
+  const downloadCsv = useCallback(() => {
+    const headerResult = headerSchema.safeParse(header)
+    const rowResults = rows.map((row) => rowSchema.safeParse(row))
+    if (!headerResult.success || rowResults.some((result) => !result.success)) {
+      return
+    }
+    const validRows = rowResults.map((result) => (result as SafeParseSuccess<DailyRowForm>).data)
+    const csv = toCsv(headerResult.data, validRows, { includeAlerts })
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    const formattedDate = headerResult.data.date.replace(/-/g, "")
+    link.href = url
+    link.download = `daily-achievements-${formattedDate || "draft"}.csv`
+    link.click()
+    URL.revokeObjectURL(url)
+  }, [header, rows, includeAlerts])
+
+  const featureEnabled = process.env.NEXT_PUBLIC_FEATURE_POCHI_RESULTS !== "false"
+
+  if (!featureEnabled) {
+    return (
+      <main className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>日次実績管理</CardTitle>
+            <CardDescription>この機能は現在無効化されています。</CardDescription>
+          </CardHeader>
+        </Card>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto flex max-w-5xl flex-col gap-8 p-6">
+      <header className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-2xl font-semibold">日次実績サマリー</h1>
+          <p className="text-sm text-muted-foreground">サービス別の利用者実績と看護時間を記録します。</p>
+        </div>
+        <section aria-labelledby="daily-header" className="grid gap-6 rounded-md border p-4">
+          <h2 id="daily-header" className="text-lg font-medium">
+            サービス情報
+          </h2>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="daily-service">サービス</Label>
+              <Select
+                value={header.service}
+                onValueChange={(value) => handleHeaderChange("service", value)}
+              >
+                <SelectTrigger
+                  id="daily-service"
+                  aria-describedby={headerErrors.service?.[0] ? "daily-service-error" : undefined}
+                >
+                  <SelectValue placeholder="サービスを選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {AVAILABLE_SERVICES.map((service) => (
+                    <SelectItem key={service.value} value={service.value}>
+                      {service.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {headerErrors.service?.[0] && (
+                <p id="daily-service-error" className="text-sm text-destructive">
+                  {headerErrors.service[0]}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="daily-date">日付</Label>
+              <Input
+                id="daily-date"
+                type="date"
+                value={header.date}
+                onChange={(event) => handleHeaderChange("date", event.target.value)}
+                aria-describedby={headerErrors.date?.[0] ? "daily-date-error" : undefined}
+              />
+              {headerErrors.date?.[0] && (
+                <p id="daily-date-error" className="text-sm text-destructive">
+                  {headerErrors.date[0]}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="daily-nurse-minutes">看護師看護時間(分)</Label>
+              <Input
+                id="daily-nurse-minutes"
+                inputMode="numeric"
+                value={header.nurseMinutes}
+                onChange={(event) => handleHeaderChange("nurseMinutes", event.target.value)}
+                aria-describedby={headerErrors.nurseMinutes?.[0] ? "daily-nurse-minutes-error" : undefined}
+              />
+              {headerErrors.nurseMinutes?.[0] && (
+                <p id="daily-nurse-minutes-error" className="text-sm text-destructive">
+                  {headerErrors.nurseMinutes[0]}
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+      </header>
+
+      <section aria-labelledby="summary-cards" className="grid gap-4 md:grid-cols-4">
+        <h2 id="summary-cards" className="sr-only">
+          サマリー
+        </h2>
+        <Card>
+          <CardHeader>
+            <CardTitle>利用者数</CardTitle>
+            <CardDescription>登録済みの利用者</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold">{summary.totalUsers}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>達成済み</CardTitle>
+            <CardDescription>実績が完了した利用者</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold text-emerald-600">
+            {summary.achievedCount}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>未完了</CardTitle>
+            <CardDescription>実績が未完了の利用者</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold text-amber-500">
+            {summary.pendingCount}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>看護時間(分)</CardTitle>
+            <CardDescription>入力した看護時間合計</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold text-sky-600">
+            {summary.nurseMinutes}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section aria-labelledby="achievements-table" className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 id="achievements-table" className="text-lg font-medium">
+              利用者別実績
+            </h2>
+            <p className="text-sm text-muted-foreground">利用者ごとの予定と実績、アラートを記録します。</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="include-alerts"
+              checked={includeAlerts}
+              onCheckedChange={(checked) => setIncludeAlerts(checked === true)}
+            />
+            <Label htmlFor="include-alerts" className="cursor-pointer">
+              アラート行をCSVに含める
+            </Label>
+            <Button variant="outline" onClick={addRow}>
+              行を追加
+            </Button>
+            <Button onClick={downloadCsv}>CSVを出力</Button>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-[180px]">利用者名</TableHead>
+                <TableHead className="min-w-[200px]">予定ケア</TableHead>
+                <TableHead className="min-w-[200px]">実績内容</TableHead>
+                <TableHead className="min-w-[120px]">達成</TableHead>
+                <TableHead className="min-w-[120px]">アラート</TableHead>
+                <TableHead className="min-w-[240px]">メモ</TableHead>
+                <TableHead className="min-w-[100px]">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row, index) => {
+                const validation = rowValidations[index]
+                const fieldErrors = validation.success ? {} : validation.error.formErrors.fieldErrors
+                const achievedId = `row-${index}-achieved`
+                const alertId = `row-${index}-alert`
+                const nameId = `row-${index}-name`
+                return (
+                  <TableRow key={row.id} className={cn(row.hasAlert && "bg-amber-50")}> 
+                    <TableCell>
+                      <div className="flex flex-col gap-2">
+                        <Label htmlFor={nameId} className="sr-only">
+                          利用者名
+                        </Label>
+                        <UserNameInput
+                          id={nameId}
+                          value={row.userName}
+                          onChange={(value) => handleRowChange(row.id, "userName", value)}
+                          suggestions={USER_SUGGESTIONS}
+                          placeholder="利用者名"
+                        />
+                        {fieldErrors.userName?.[0] && (
+                          <p className="text-sm text-destructive">{fieldErrors.userName[0]}</p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col gap-2">
+                        <Label htmlFor={`row-${index}-planned`} className="sr-only">
+                          予定ケア
+                        </Label>
+                        <Input
+                          id={`row-${index}-planned`}
+                          value={row.plannedCare}
+                          onChange={(event) => handleRowChange(row.id, "plannedCare", event.target.value)}
+                        />
+                        {fieldErrors.plannedCare?.[0] && (
+                          <p className="text-sm text-destructive">{fieldErrors.plannedCare[0]}</p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col gap-2">
+                        <Label htmlFor={`row-${index}-achieved-description`} className="sr-only">
+                          実績内容
+                        </Label>
+                        <Textarea
+                          id={`row-${index}-achieved-description`}
+                          value={row.achievedDescription}
+                          onChange={(event) => handleRowChange(row.id, "achievedDescription", event.target.value)}
+                        />
+                        {fieldErrors.achievedDescription?.[0] && (
+                          <p className="text-sm text-destructive">{fieldErrors.achievedDescription[0]}</p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={achievedId}
+                          checked={row.achieved}
+                          onCheckedChange={(checked) =>
+                            handleRowChange(row.id, "achieved", checked === true)
+                          }
+                        />
+                        <Label htmlFor={achievedId} className="cursor-pointer">
+                          達成
+                        </Label>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={alertId}
+                          checked={row.hasAlert}
+                          onCheckedChange={(checked) =>
+                            handleRowChange(row.id, "hasAlert", checked === true)
+                          }
+                        />
+                        <Label htmlFor={alertId} className="cursor-pointer">
+                          アラート
+                        </Label>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col gap-2">
+                        <Label htmlFor={`row-${index}-notes`} className="sr-only">
+                          メモ
+                        </Label>
+                        <Textarea
+                          id={`row-${index}-notes`}
+                          value={row.notes ?? ""}
+                          onChange={(event) => handleRowChange(row.id, "notes", event.target.value)}
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="ghost" onClick={() => removeRow(row.id)}>
+                        削除
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/(pochi)/manage/achievements/daily/schema.ts
+++ b/app/(pochi)/manage/achievements/daily/schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+
+export const headerSchema = z.object({
+  service: z.string().min(1, "サービスを選択してください。"),
+  date: z
+    .string()
+    .min(1, "日付を入力してください。")
+    .refine((value) => {
+      if (!value) return false
+      const parsed = Date.parse(value)
+      return Number.isFinite(parsed)
+    }, "有効な日付を入力してください。"),
+  nurseMinutes: z
+    .string()
+    .min(1, "看護師看護時間を入力してください。")
+    .refine((value) => /^\\d+$/.test(value), "数字で入力してください。"),
+})
+
+export const rowSchema = z.object({
+  id: z.string(),
+  userName: z.string().min(1, "利用者名を入力してください。"),
+  plannedCare: z.string().min(1, "予定ケアを入力してください。"),
+  achievedDescription: z.string().min(1, "実績内容を入力してください。"),
+  achieved: z.boolean(),
+  hasAlert: z.boolean(),
+  notes: z.string().optional(),
+})
+
+export const draftSchema = z.object({
+  header: headerSchema,
+  rows: z.array(rowSchema),
+})
+
+export type DailyHeaderForm = z.infer<typeof headerSchema>
+export type DailyRowForm = z.infer<typeof rowSchema>
+export type DailyDraft = z.infer<typeof draftSchema>

--- a/app/(pochi)/manage/achievements/daily/user-name-input.tsx
+++ b/app/(pochi)/manage/achievements/daily/user-name-input.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+
+interface UserNameInputProps {
+  id: string
+  value: string
+  onChange: (value: string) => void
+  suggestions: string[]
+  placeholder?: string
+}
+
+export const UserNameInput = ({ id, value, onChange, suggestions, placeholder }: UserNameInputProps) => {
+  const listId = `${id}-suggestions`
+
+  return (
+    <>
+      <Input
+        id={id}
+        list={listId}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      <datalist id={listId}>
+        {suggestions.map((name) => (
+          <option key={name} value={name} />
+        ))}
+      </datalist>
+    </>
+  )
+}

--- a/app/(pochi)/users/page.tsx
+++ b/app/(pochi)/users/page.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+
+interface PochiUser {
+  id: string
+  name: string
+  scheduleSummary: string
+  nextSchedule: string
+  timecardStatus: string
+  hasTimecard: boolean
+}
+
+const USER_GROUPS: { id: string; label: string; users: PochiUser[] }[] = [
+  {
+    id: "day",
+    label: "日勤グループ",
+    users: [
+      {
+        id: "1",
+        name: "田中太郎",
+        scheduleSummary: "09:00-17:00",
+        nextSchedule: "明日 09:00 ケア記録",
+        timecardStatus: "未打刻",
+        hasTimecard: true,
+      },
+      {
+        id: "2",
+        name: "山田花子",
+        scheduleSummary: "09:30-16:30",
+        nextSchedule: "本日 15:00 リハビリ",
+        timecardStatus: "打刻済み",
+        hasTimecard: true,
+      },
+    ],
+  },
+  {
+    id: "evening",
+    label: "夕方グループ",
+    users: [
+      {
+        id: "3",
+        name: "佐藤健",
+        scheduleSummary: "12:00-20:00",
+        nextSchedule: "明後日 13:00 外出同行",
+        timecardStatus: "打刻不要",
+        hasTimecard: false,
+      },
+      {
+        id: "4",
+        name: "伊藤蓮",
+        scheduleSummary: "13:00-19:00",
+        nextSchedule: "来週 10:00 訪問",
+        timecardStatus: "未打刻",
+        hasTimecard: true,
+      },
+    ],
+  },
+]
+
+const FEATURE_FLAG = process.env.NEXT_PUBLIC_FEATURE_POCHI_USERS
+
+const isFeatureEnabled = FEATURE_FLAG === undefined || FEATURE_FLAG === "true" || FEATURE_FLAG === "1"
+
+export default function UsersPage() {
+  if (!isFeatureEnabled) {
+    return (
+      <main className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>利用者管理</CardTitle>
+            <CardDescription>この機能は現在無効化されています。</CardDescription>
+          </CardHeader>
+        </Card>
+      </main>
+    )
+  }
+
+  const [selectedGroup, setSelectedGroup] = useState(USER_GROUPS[0]?.id ?? "")
+  const [showTimecard, setShowTimecard] = useState(false)
+
+  const users = useMemo(() => {
+    const group = USER_GROUPS.find((item) => item.id === selectedGroup)
+    return group?.users ?? []
+  }, [selectedGroup])
+
+  return (
+    <main className="mx-auto flex max-w-4xl flex-col gap-8 p-6">
+      <header className="flex flex-col gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">利用者管理</h1>
+          <p className="text-sm text-muted-foreground">グループ別に利用者を切り替え、予定と打刻の状態を確認します。</p>
+        </div>
+        <div className="grid gap-4 rounded-md border p-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="user-group">グループ</Label>
+            <Select value={selectedGroup} onValueChange={(value) => setSelectedGroup(value)}>
+              <SelectTrigger id="user-group">
+                <SelectValue placeholder="グループを選択" />
+              </SelectTrigger>
+              <SelectContent>
+                {USER_GROUPS.map((group) => (
+                  <SelectItem key={group.id} value={group.id}>
+                    {group.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="show-timecard"
+              checked={showTimecard}
+              onCheckedChange={(checked) => setShowTimecard(checked === true)}
+            />
+            <Label htmlFor="show-timecard" className="cursor-pointer">
+              タイムカードを表示
+            </Label>
+          </div>
+        </div>
+      </header>
+
+      <section aria-labelledby="users-section" className="flex flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 id="users-section" className="text-lg font-medium">
+              利用者一覧
+            </h2>
+            <p className="text-sm text-muted-foreground">予定カレンダーと打刻アクションの骨子を確認できます。</p>
+          </div>
+          <Button variant="outline">利用者を追加</Button>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {users.map((user) => (
+            <Card key={user.id} className="flex flex-col">
+              <CardHeader>
+                <CardTitle>{user.name}</CardTitle>
+                <CardDescription>予定: {user.scheduleSummary}</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col gap-4">
+                <div>
+                  <h3 className="text-sm font-medium text-muted-foreground">予定カレンダー</h3>
+                  <p className="text-base">{user.nextSchedule}</p>
+                </div>
+                {showTimecard && (
+                  <div className="flex flex-col gap-2">
+                    <Separator />
+                    <h3 className="text-sm font-medium text-muted-foreground">打刻</h3>
+                    {user.hasTimecard ? (
+                      <>
+                        <p className="text-base">{user.timecardStatus}</p>
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline">
+                            出勤
+                          </Button>
+                          <Button size="sm" variant="outline">
+                            退勤
+                          </Button>
+                        </div>
+                      </>
+                    ) : (
+                      <p className="text-base text-muted-foreground">タイムカード対象外の利用者です。</p>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+              <CardFooter className="justify-end gap-2">
+                <Button size="sm" variant="ghost">
+                  詳細
+                </Button>
+                <Button size="sm">予定を編集</Button>
+              </CardFooter>
+            </Card>
+          ))}
+          {users.length === 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>表示する利用者がいません</CardTitle>
+                <CardDescription>条件を変更して再度お試しください。</CardDescription>
+              </CardHeader>
+            </Card>
+          )}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/lib/model-adapters.ts
+++ b/lib/model-adapters.ts
@@ -1,42 +1,64 @@
-﻿import type { DiaryEntry, MedicalRecord } from "../lib/db";
-import { UnifiedEntrySchema } from "../schemas/unified";
-import type { UnifiedEntry, UnifiedRecordT, UnifiedCategory } from "../schemas/unified";
+import type { DiaryEntry, MedicalRecord } from "../lib/db"
+import { UnifiedEntrySchema } from "../schemas/unified"
+import type { UnifiedEntry, UnifiedRecordT, UnifiedCategory } from "../schemas/unified"
 
-export type JournalEntry = {
-  id: string;
-  date: string;
-  category: string;
-  data: Record<string, any>;
-};
+export interface JournalEntry {
+  title: string
+  content: string
+  category: string
+  timestamp?: string
+  tags?: string[]
+}
 
-export function journalToUnified(j: JournalEntry): UnifiedEntry {
-  const base = {
-    id: j.id,
-    date: j.date,
+interface JournalToUnifiedOptions {
+  id?: string
+  userId?: string
+  serviceId?: string
+  timestamp?: string
+}
+
+const createRandomId = () => {
+  if (typeof globalThis.crypto !== "undefined" && typeof globalThis.crypto.randomUUID === "function") {
+    return globalThis.crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+export function journalToUnified(j: JournalEntry, options?: JournalToUnifiedOptions): UnifiedEntry {
+  const timestamp = options?.timestamp ?? j.timestamp ?? new Date().toISOString()
+  const base: Partial<UnifiedEntry> = {
+    id: options?.id ?? createRandomId(),
+    userId: options?.userId,
+    serviceId: options?.serviceId,
+    date: timestamp,
+    title: j.title,
+    content: j.content,
     category: (j.category as UnifiedCategory) || "other",
+    tags: j.tags ?? [],
     records: [
       {
-        time: j.date,
-        notes: JSON.stringify(j.data),
+        time: timestamp,
+        notes: j.content,
       },
     ],
-    createdAt: j.date,
-    updatedAt: j.date,
-  } as Partial<UnifiedEntry>;
-  return UnifiedEntrySchema.parse(base);
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+  return UnifiedEntrySchema.parse(base)
 }
 
 export function unifiedToJournal(u: UnifiedEntry): JournalEntry {
   return {
-    id: u.id,
-    date: u.date,
+    title: u.title ?? "",
+    content: u.content ?? "",
     category: u.category,
-    data: u.records[0] ? JSON.parse(u.records[0].notes || "{}") : {},
-  };
+    timestamp: u.date,
+    tags: u.tags,
+  }
 }
 
 export function dexieDiaryToUnified(d: DiaryEntry, opts?: { userId?: string; serviceId?: string }): UnifiedEntry {
-  const records: UnifiedRecordT[] = d.records.map(r => ({
+  const records: UnifiedRecordT[] = d.records.map((r) => ({
     time: r.time,
     notes: r.notes,
     vitals: {
@@ -44,24 +66,26 @@ export function dexieDiaryToUnified(d: DiaryEntry, opts?: { userId?: string; ser
       temperature: r.temperature,
       oxygenSaturation: r.oxygenSaturation,
     },
-    seizure: r.seizureType ? {
-      seizureType: r.seizureType,
-    } : undefined,
+    seizure: r.seizureType
+      ? {
+          seizureType: r.seizureType,
+        }
+      : undefined,
     pee: r.pee,
     poo: r.poo,
-  }));
-  
-  let category: UnifiedCategory = "other";
-  if (d.records.some(r => r.heartRate || r.temperature || r.oxygenSaturation)) category = "vitals";
-  else if (d.records.some(r => r.seizureType)) category = "seizure";
+  }))
+
+  let category: UnifiedCategory = "other"
+  if (d.records.some((r) => r.heartRate || r.temperature || r.oxygenSaturation)) category = "vitals"
+  else if (d.records.some((r) => r.seizureType)) category = "seizure"
 
   const base = {
     id: d.id,
     date: d.date,
     category,
     records,
-    attachments: (d.photos || []).map(uri => ({ type: "photo" as const, uri })),
-    editHistory: (d.editHistory || []).map(eh => ({
+    attachments: (d.photos || []).map((uri) => ({ type: "photo" as const, uri })),
+    editHistory: (d.editHistory || []).map((eh) => ({
       timestamp: eh.timestamp,
       editor: eh.editor,
       changes: eh.changes,
@@ -70,12 +94,12 @@ export function dexieDiaryToUnified(d: DiaryEntry, opts?: { userId?: string; ser
     updatedAt: d.updatedAt,
     userId: opts?.userId,
     serviceId: opts?.serviceId,
-  } as Partial<UnifiedEntry>;
-  return UnifiedEntrySchema.parse(base);
+  } as Partial<UnifiedEntry>
+  return UnifiedEntrySchema.parse(base)
 }
 
 export function unifiedToDexieDiary(u: UnifiedEntry): DiaryEntry {
-  const records: MedicalRecord[] = u.records.map(r => ({
+  const records: MedicalRecord[] = u.records.map((r) => ({
     time: r.time,
     heartRate: r.vitals?.heartRate,
     temperature: r.vitals?.temperature,
@@ -84,19 +108,19 @@ export function unifiedToDexieDiary(u: UnifiedEntry): DiaryEntry {
     notes: r.notes,
     pee: r.pee,
     poo: r.poo,
-  }));
-  
+  }))
+
   return {
     id: u.id,
     date: u.date,
     records,
-    photos: u.attachments?.filter(a => a.type === "photo").map(a => a.uri),
-    editHistory: u.editHistory?.map(eh => ({
+    photos: u.attachments?.filter((a) => a.type === "photo").map((a) => a.uri),
+    editHistory: u.editHistory?.map((eh) => ({
       timestamp: eh.timestamp,
       editor: eh.editor,
       changes: eh.changes,
     })),
     createdAt: u.createdAt,
     updatedAt: u.updatedAt,
-  };
+  }
 }


### PR DESCRIPTION
## Summary
- add daily achievements workspace under (pochi) with validation, CSV export, and draft persistence
- introduce (pochi) users overview with group switching and timecard visibility toggle
- expand journal adapters to support metadata and satisfy updated tests

## Testing
- CI=1 pnpm build
- pnpm -s lint:strict
- pnpm -s test

------
https://chatgpt.com/codex/tasks/task_e_690ae3077fa4832099b8022333c8f1f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daily achievements management page with automatic draft persistence, real-time validation, and CSV export capability.
  * Introduced users management interface with group-based filtering and optional timecard visibility toggle.

* **Refactor**
  * Updated internal data model adapters for improved journal entry handling and metadata management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->