### PR TITLE
fix(pochi): disable CSV export until inputs are valid

### DIFF
--- a/app/(pochi)/manage/achievements/daily/page.tsx
+++ b/app/(pochi)/manage/achievements/daily/page.tsx
@@ -101,6 +101,7 @@ export default function DailyAchievementsPage() {
     ? {}
     : headerValidation.error.formErrors.fieldErrors
   const rowValidations = useMemo(() => rows.map((row) => rowSchema.safeParse(row)), [rows])
+  const isFormValid = headerValidation.success && rowValidations.every((result) => result.success)
 
   const summary = useMemo(() => {
     const totalUsers = rows.length
@@ -303,9 +304,17 @@ export default function DailyAchievementsPage() {
             <Button variant="outline" onClick={addRow}>
               行を追加
             </Button>
-            <Button onClick={downloadCsv}>CSVを出力</Button>
+            <Button onClick={downloadCsv} disabled={!isFormValid}>
+              CSVを出力
+            </Button>
           </div>
         </div>
+
+        {!isFormValid && (
+          <p className="text-sm text-muted-foreground" role="status">
+            入力内容に不足があります。すべてのフィールドを確認するとCSVを出力できます。
+          </p>
+        )}
 
         <div className="overflow-x-auto rounded-md border">
           <Table>


### PR DESCRIPTION
## Summary
- disable the CSV出力ボタン until 日次実績フォームがheader/rowともに有効になる
- surface inline status text so operators know why CSV出力が無効化されている

### Checklist
- [x] (pochi) 配下のみの差分である
- [x] pnpm -s build / lint:strict / test が成功（既存39テスト不変）
- [x] CSV: BOM(UTF-8) + CRLF + boolean(0/1)
- [x] LocalStorage 下書き保存（date×service単位）
- [x] a11y: CheckboxはLabelとidのペア／フォームはラベル有り
- [x] 旧 /achievements/daily は将来の `next.config.js > redirects()` で恒久リダイレクト予定

### 運用ガード（人手設定）
- main の Branch protection: Required status checks に **build / lint:strict / test** を登録してください（設定が通るまでマージ不可）。
- CODEOWNERS: `app/(pochi)/**` をレビュアグループに自動アサイン


------
https://chatgpt.com/codex/tasks/task_e_690affd561d483208271ad7c8949a310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status message that provides clear guidance to users about completing all required fields in the daily achievements section before proceeding with CSV export.

* **Bug Fixes**
  * Improved form validation system: CSV download button now automatically disables when any required fields are incomplete, preventing exports of invalid data and maintaining data quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->