### PR TITLE
fix(ci): enhance automerge triggers (unlabeled + debug)

### DIFF
--- a/.github/workflows/ci-automerge.yml
+++ b/.github/workflows/ci-automerge.yml
@@ -2,7 +2,7 @@ name: ci-automerge
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   workflow_dispatch:
     inputs:
       pr:
@@ -34,6 +34,14 @@ jobs:
     timeout-minutes: 30
     
     steps:
+      - name: Debug gating context
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "actor=${{ github.actor }}"
+          echo "head_ref=${{ github.head_ref }}"
+          echo "draft=${{ github.event.pull_request.draft }}"
+          echo "labels=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r '.[].name' | paste -sd, -)"
+      
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Changes

- Add \unlabeled\ and \eady_for_review\ to pull_request triggers
- Add debug context output (event_name, actor, head_ref, draft, labels)

## Reason

PR #148 had \ux-ready\ label but workflow was skipped. This enhancement:...
1. Enables re-evaluation when labels are removed
2. Provides visibility into gating conditions
3. Supports ready_for_review event for draftready transitions

## Related

- Fixes: Workflow skipped despite \ux-ready\ label present
- Ref: docs/ci-automerge-guide.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to improve automation and debugging capabilities. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->